### PR TITLE
fix: add MimeResponds module for Rails 7.1 compatibility

### DIFF
--- a/backend/app/controllers/api/v1/base_controller.rb
+++ b/backend/app/controllers/api/v1/base_controller.rb
@@ -1,6 +1,7 @@
 module Api
   module V1
     class BaseController < ApplicationController
+      include ActionController::MimeResponds
       respond_to :json
 
       private


### PR DESCRIPTION
## 📝 Summary  
Included the `ActionController::MimeResponds` module in `Api::V1::BaseController` to fix a `respond_to` undefined method error after upgrading to Rails 7.1.

## 🔧 Changes  
- Included `ActionController::MimeResponds` in API base controller  
- Fixed `respond_to` undefined method error caused by Rails 7.1 upgrade

## 📌 Related Issues  
<!-- If this PR closes an issue, you can use:  
Close #issue_number  
-->
N/A

## 🧪 Test Plan  
- [x] Confirmed API responses still return correct JSON formats  
- [x] Verified no regression errors after including the module

## 💭 Notes (Optional)  
This issue arose due to a change in Rails 7.1 where `ActionController::API` no longer includes `MimeResponds` by default. Explicit inclusion is now required when using `respond_to` in API-only controllers.
