### PR TITLE
chore: optimize Puma configuration

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,8 +19,5 @@ RUN bundle config set --local force_ruby_platform true && \
 # アプリケーションのコピー
 COPY . .
 
-# ポートの設定
-EXPOSE 8000
-
 # サーバーの起動
-CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0", "-p", "8000"] 
+CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]

--- a/backend/config/puma.rb
+++ b/backend/config/puma.rb
@@ -15,7 +15,7 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT") { 8000 }
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
# Optimize Puma Configuration

## 📝 Summary
Optimized the Puma server configuration and startup process for better performance and maintainability. Changed the server startup command to use Puma directly and updated port configurations.

## 🔧 Changes
- Changed server start command from `rails server` to `bundle exec puma -C config/puma.rb`
- Removed redundant `EXPOSE 8000` directive from Dockerfile
- Updated default port from 3000 to 8000 in Puma configuration


## 🧪 Test Plan
- [ ] Verified that the application starts correctly with the new Puma configuration
- [ ] Confirmed that the server is accessible on port 8000
- [ ] Tested the application in both development and production environments

## 💭 Notes
- The direct use of Puma instead of `rails server` provides better control over the server configuration
- Port 8000 is now consistently used across all environments
- The `EXPOSE` directive was redundant as the port is already specified in the Puma configuration