### PR TITLE
chore: ensure Puma pids directory exists

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,4 +20,4 @@ RUN bundle config set --local force_ruby_platform true && \
 COPY . .
 
 # サーバーの起動
-CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]
+CMD ["sh", "-c", "mkdir -p tmp/pids && bundle exec puma -C config/puma.rb"]


### PR DESCRIPTION
## 📝 Summary
Added a step to create the `tmp/pids` directory before starting Puma server to prevent potential startup issues. This ensures that Puma has the necessary directory structure for its PID files.

## 🔧 Changes
- Added `mkdir -p tmp/pids` command before Puma server start
- Modified Dockerfile to use shell command for combining directory creation and server start

## 📌 Related Issues
N/A

## 🧪 Test Plan
- [x] Verified that the `tmp/pids` directory is created on container startup
- [x] Confirmed that Puma starts successfully with the new configuration
- [x] Tested the application in both development and production environments

## 💭 Notes
- The `tmp/pids` directory is required by Puma for storing its process ID file
- Using `mkdir -p` ensures the command won't fail if the directory already exists
- This change improves the reliability of the application startup process
