### PR TITLE
Refactor: use env var for api url

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,9 +2,8 @@ import type { Metadata } from 'next'
 import './globals.css'
 
 export const metadata: Metadata = {
-  title: 'v0 App',
-  description: 'Created with v0',
-  generator: 'v0.dev',
+  title: 'Shunsuke Kido | Web Developer Portfolio',
+  description: 'Hi, I\'m Shunsuke Kido - I enjoy building web apps with Rails and Next.js.'
 }
 
 export default function RootLayout({

--- a/frontend/components/contact.tsx
+++ b/frontend/components/contact.tsx
@@ -11,6 +11,8 @@ import { Textarea } from "@/components/ui/textarea"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { useToast } from "@/hooks/use-toast"
 
+const API_URL = process.env.NEXT_PUBLIC_API_URL
+
 export default function Contact() {
   const { toast } = useToast()
   const [formData, setFormData] = useState({
@@ -31,7 +33,7 @@ export default function Contact() {
     setIsSubmitting(true)
 
     try {
-      const response = await fetch("http://localhost:8000/api/v1/contact", {
+      const response = await fetch(`${API_URL}/api/v1/contact`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/frontend/components/header.tsx
+++ b/frontend/components/header.tsx
@@ -37,7 +37,7 @@ export default function Header() {
     >
       <div className="container mx-auto px-4 py-4 flex items-center justify-between">
         <Link href="/" className="text-xl font-bold">
-          About Me
+          About Kido
         </Link>
 
         <div className="hidden md:flex items-center space-x-6">


### PR DESCRIPTION
## 📝 Summary
Refactored the contact form to use environment variables for API URL and updated site metadata for better personal branding.

## 🔧 Changes
- Replaced hardcoded API URL with `NEXT_PUBLIC_API_URL` environment variable in contact form
- Updated site title to "Shunsuke Kido | Web Developer Portfolio"
- Updated site description to "Hi, I'm Shunsuke Kido - I enjoy building web apps with Rails and Next.js."
- Changed header title from "About Me" to "About Kido"

## 📌 Related Issues
<!-- No related issues -->

## 🧪 Test Plan
- [x] Verify that contact form works in development environment (http://localhost:8000)
- [x] Verify that contact form works in production environment (https://api.about-me.kidoshunsuke.com)
- [x] Confirm that site metadata is correctly displayed in browser tab
- [x] Check that header title is correctly displayed

## 💭 Notes
- The API URL is now configurable through environment variables, making it easier to switch between development and production environments
- Site metadata has been updated to better reflect personal branding and professional focus
- No functional changes to the contact form's behavior, only the API endpoint configuration has been modified