### PR TITLE
fix: improve responsive design of skill section tabs

### DIFF
--- a/frontend/components/skills.tsx
+++ b/frontend/components/skills.tsx
@@ -49,9 +49,9 @@ export default function Skills() {
 
         <Tabs defaultValue="languages" className="w-full max-w-4xl mx-auto">
           <TabsList className="grid w-full grid-cols-3 mb-8">
-            <TabsTrigger value="languages">Languages</TabsTrigger>
-            <TabsTrigger value="frameworks">Frameworks & Libraries</TabsTrigger>
-            <TabsTrigger value="tools">Tools & Others</TabsTrigger>
+            <TabsTrigger value="languages" className="text-sm sm:text-base">Lang</TabsTrigger>
+            <TabsTrigger value="frameworks" className="text-sm sm:text-base">Frameworks</TabsTrigger>
+            <TabsTrigger value="tools" className="text-sm sm:text-base">Tools</TabsTrigger>
           </TabsList>
 
           <TabsContent value="languages">


### PR DESCRIPTION
## 📝 Summary
Improved the responsive design of skill section tabs to prevent text overflow on mobile devices.

## 🔧 Changes
- Shortened tab trigger text for better mobile display
- Added responsive font size classes
  - Mobile: `text-sm`
  - Tablet and above: `sm:text-base`
- Simplified tab labels for better readability

## 📌 Related Issues
N/A

## 🧪 Test Plan
- [ ] Verified tab display on mobile devices (iPhone SE, iPhone 12)
- [ ] Confirmed tab display on tablet devices (iPad)
- [ ] Checked tab display on desktop browsers (Chrome, Safari)
- [ ] Ensured tab functionality works correctly across all devices

## 💭 Notes
The changes maintain the same functionality while improving the user experience on mobile devices. The shortened labels are still descriptive enough to understand the content of each tab.